### PR TITLE
Elasticsearch 2.x support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <url>https://github.com/ingenieux/elasticsearch-newrelic-plugin/</url>
 
     <properties>
-        <elasticsearch.version>1.3.2</elasticsearch.version>
+        <elasticsearch.version>2.2.0</elasticsearch.version>
         <hamcrest.version>1.3</hamcrest.version>
         <skipTests>true</skipTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.newrelic.agent.java</groupId>
             <artifactId>newrelic-api</artifactId>
-            <version>3.12.1</version>
+            <version>3.26.1</version>
         </dependency>
 
         <dependency>
@@ -66,6 +66,12 @@
             <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>16.0.1</version>
         </dependency>
 
         <dependency>
@@ -95,6 +101,7 @@
             <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,10 +16,16 @@
     <url>https://github.com/ingenieux/elasticsearch-newrelic-plugin/</url>
 
     <properties>
+        <elasticsearch.assembley.descriptor></elasticsearch.assembley.descriptor>
         <elasticsearch.version>2.2.0</elasticsearch.version>
+        <elasticsearch.plugin.site>false</elasticsearch.plugin.site>
+        <elasticsearch.plugin.classname>org.elasticsearch.plugin.newrelic.NewRelicPlugin</elasticsearch.plugin.classname>
+        <elasticsearch.plugin.jvm>true</elasticsearch.plugin.jvm>
+        <elasticsearch.plugin.isolated>true</elasticsearch.plugin.isolated>
         <hamcrest.version>1.3</hamcrest.version>
         <skipTests>true</skipTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
     </properties>
 
     <licenses>
@@ -69,12 +75,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>16.0.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
@@ -111,8 +111,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -15,4 +15,11 @@
             </excludes>
         </dependencySet>
     </dependencySets>
+    <files>
+        <file>
+            <source>src/main/resources/plugin-metadata/plugin-descriptor.properties</source>
+            <outputDirectory></outputDirectory>
+            <filtered>true</filtered>
+        </file>
+    </files>
 </assembly>

--- a/src/main/java/org/elasticsearch/plugin/newrelic/NewRelicPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/newrelic/NewRelicPlugin.java
@@ -1,13 +1,13 @@
 package org.elasticsearch.plugin.newrelic;
 
-import org.elasticsearch.common.collect.Lists;
 import org.elasticsearch.common.component.LifecycleComponent;
-import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.service.newrelic.NewRelicService;
 
 import java.util.Collection;
+import java.util.Collections;
 
-public class NewRelicPlugin extends AbstractPlugin {
+public class NewRelicPlugin extends Plugin {
 
     public String name() {
         return "newrelic";
@@ -18,8 +18,8 @@ public class NewRelicPlugin extends AbstractPlugin {
     }
 
     @SuppressWarnings("rawtypes")
-    @Override public Collection<Class<? extends LifecycleComponent>> services() {
-        Collection<Class<? extends LifecycleComponent>> services = Lists.newArrayList();
+    @Override public Collection<Class<? extends LifecycleComponent>> nodeServices() {
+        Collection<Class<? extends LifecycleComponent>> services = Collections.emptyList();
         services.add(NewRelicService.class);
         return services;
     }

--- a/src/main/java/org/elasticsearch/plugin/newrelic/NewRelicPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/newrelic/NewRelicPlugin.java
@@ -6,7 +6,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.service.newrelic.NewRelicService;
 
 import java.util.Collection;
-import java.util.Collections;
 
 public class NewRelicPlugin extends Plugin {
 

--- a/src/main/java/org/elasticsearch/plugin/newrelic/NewRelicPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/newrelic/NewRelicPlugin.java
@@ -1,5 +1,6 @@
 package org.elasticsearch.plugin.newrelic;
 
+import com.google.common.collect.Lists;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.service.newrelic.NewRelicService;
@@ -19,7 +20,7 @@ public class NewRelicPlugin extends Plugin {
 
     @SuppressWarnings("rawtypes")
     @Override public Collection<Class<? extends LifecycleComponent>> nodeServices() {
-        Collection<Class<? extends LifecycleComponent>> services = Collections.emptyList();
+        Collection<Class<? extends LifecycleComponent>> services = Lists.newArrayList();
         services.add(NewRelicService.class);
         return services;
     }

--- a/src/main/java/org/elasticsearch/service/newrelic/NewRelicService.java
+++ b/src/main/java/org/elasticsearch/service/newrelic/NewRelicService.java
@@ -4,6 +4,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -18,10 +19,8 @@ import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.NodeIndicesStats;
-import org.elasticsearch.node.Node;
 import org.elasticsearch.node.service.NodeService;
-
-import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.plugin.newrelic.NewRelicPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,8 +45,7 @@ public class NewRelicService extends AbstractLifecycleComponent<NewRelicService>
                                    IndicesService indicesService,
                                    NodeService nodeService) {
         super(settings);
-        Node node = NodeBuilder.nodeBuilder().node();
-        this.client = node.client();
+        this.client = TransportClient.builder().addPlugin(NewRelicPlugin.class).settings(settings).build();
         this.clusterService = clusterService;
         this.indicesService = indicesService;
         this.nodeService = nodeService;

--- a/src/main/resources/plugin-metadata/plugin-descriptor.properties
+++ b/src/main/resources/plugin-metadata/plugin-descriptor.properties
@@ -1,0 +1,44 @@
+description=${project.description}
+version=${project.version}
+#
+# 'name': the plugin name
+name=${project.name}
+
+### mandatory elements for site plugins:
+#
+# 'site': set to true to indicate contents of the _site/
+#  directory in the root of the plugin should be served.
+site=${elasticsearch.plugin.site}
+#
+### mandatory elements for jvm plugins :
+#
+# 'jvm': true if the 'classname' class should be loaded
+#  from jar files in the root directory of the plugin.
+#  Note that only jar files in the root directory are
+#  added to the classpath for the plugin! If you need
+#  other resources, package them into a resources jar.
+jvm=${elasticsearch.plugin.jvm}
+#
+# 'classname': the name of the class to load, fully-qualified.
+classname=${elasticsearch.plugin.classname}
+#
+# 'java.version' version of java the code is built against
+# use the system property java.specification.version
+# version string must be a sequence of nonnegative decimal integers
+# separated by "."'s and may have leading zeros
+java.version=1.8
+#
+# 'elasticsearch.version' version of elasticsearch compiled against
+# You will have to release a new version of the plugin for each new
+# elasticsearch release. This version is checked when the plugin
+# is loaded so Elasticsearch will refuse to start in the presence of
+# plugins with the incorrect elasticsearch.version.
+elasticsearch.version=${elasticsearch.version}
+#
+### deprecated elements for jvm plugins :
+#
+# 'isolated': true if the plugin should have its own classloader.
+# passing false is deprecated, and only intended to support plugins
+# that have hard dependencies against each other. If this is
+# not specified, then the plugin is isolated by default.
+isolated=${elasticsearch.plugin.isolated}

--- a/src/test/java/org/elasticsearch/module/graphite/test/ElasticSearchPluginIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/module/graphite/test/ElasticSearchPluginIntegrationTest.java
@@ -1,7 +1,7 @@
 package org.elasticsearch.module.graphite.test;
 
+import com.google.common.collect.Iterables;
 import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.common.collect.Iterables;
 import org.elasticsearch.common.inject.ProvisionException;
 import org.elasticsearch.node.Node;
 import org.junit.After;
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 import java.util.UUID;
 
-import static org.elasticsearch.common.base.Predicates.containsPattern;
+import static com.google.common.base.Predicates.containsPattern;
 import static org.elasticsearch.module.graphite.test.NodeTestHelper.createNode;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -102,7 +102,7 @@ public class ElasticSearchPluginIntegrationTest {
         Node origNode = node;
         node = createNode(clusterName, GRAPHITE_SERVER_PORT, "1s");
         graphiteMockServer.content.clear();
-        origNode.stop();
+        origNode.close();
         indexResponse = indexElement(node, index, type, "value");
         assertThat(indexResponse.getId(), is(notNullValue()));
 

--- a/src/test/java/org/elasticsearch/module/graphite/test/GraphiteMockServer.java
+++ b/src/test/java/org/elasticsearch/module/graphite/test/GraphiteMockServer.java
@@ -1,6 +1,6 @@
 package org.elasticsearch.module.graphite.test;
 
-import org.elasticsearch.common.collect.Lists;
+import com.google.common.collect.Lists;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/test/java/org/elasticsearch/module/graphite/test/NodeTestHelper.java
+++ b/src/test/java/org/elasticsearch/module/graphite/test/NodeTestHelper.java
@@ -2,7 +2,7 @@ package org.elasticsearch.module.graphite.test;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.log4j.LogConfigurator;
-import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 
@@ -16,7 +16,7 @@ public class NodeTestHelper {
 
     public static Node createNode(String clusterName, int graphitePort, String refreshInterval, String includeRegex,
                                   String excludeRegex) throws IOException {
-        ImmutableSettings.Builder settingsBuilder = ImmutableSettings.settingsBuilder();
+        Settings.Builder settingsBuilder = Settings.settingsBuilder();
 
         settingsBuilder.put("path.conf", NodeTestHelper.class.getResource("/").getFile());
 
@@ -37,7 +37,7 @@ public class NodeTestHelper {
             settingsBuilder.put("metrics.newrelic.exclude", excludeRegex);
         }
 
-        LogConfigurator.configure(settingsBuilder.build());
+        LogConfigurator.configure(settingsBuilder.build(), true);
 
         return NodeBuilder.nodeBuilder().settings(settingsBuilder.build()).node();
     }


### PR DESCRIPTION
- using Elasticsearch 2.2 Java SDK
- remove some metrics which removed or deprecated in Elasticsearch 2.x
